### PR TITLE
V3 permissions update [GEAR-430]

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,32 @@
+name-template: 'v$NEXT_PATCH_VERSION'
+tag-template: 'v$NEXT_PATCH_VERSION'
+categories:
+  - title: 'Features'
+    labels:
+      - 'feature'
+      - 'enhancement'
+      - 'enh'
+  - title: 'Fixes'
+    labels:
+      - 'fix'
+      - 'bugfix'
+      - 'bug'
+  - title: 'Documentation'
+    labels:
+      - 'doc'
+      - 'documentation'
+  - title: 'Maintenance'
+    labels:
+      - 'chore'
+      - 'maintenance'
+change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
+template: |
+  _[ADD SUMMARY OF WHAT CHANGED]_
+
+  # What's Changed
+
+  $CHANGES
+
+  # Impact On Gear Output
+
+  _[LIST HOW STRUCTURE AND/OR VALUES OF GEAR OUTPUTS (e.g. FILES AND METADATA) ARE IMPACTED]_

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,16 @@
+name: Release Drafter
+
+on:
+  push:
+    # branches to consider in the event; optional, defaults to all
+    branches:
+      - master
+
+jobs:
+  update_release_draft:
+    runs-on: ubuntu-latest
+    steps:
+      # Drafts your next Release notes as Pull Requests are merged into "master"
+      - uses: release-drafter/release-drafter@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/manifest.json
+++ b/manifest.json
@@ -7,12 +7,12 @@
   "license": "MIT",
   "source": "https://github.com/flywheel-apps/GRP-15",
   "url": "https://github.com/flywheel-apps/GRP-15",
-  "version": "2.0.0_dev5",
+  "version": "2.0.0",
   "environment": {},
   "custom": {
     "gear-builder": {
       "category": "analysis",
-      "image": "flywheel/grp-15-project-settings:1.0.0"
+      "image": "flywheel/grp-15-project-settings:2.0.0"
     },
     "flywheel": {
       "suite": "Data Export"

--- a/manifest.json
+++ b/manifest.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "source": "https://github.com/flywheel-apps/GRP-15",
   "url": "https://github.com/flywheel-apps/GRP-15",
-  "version": "1.0.0",
+  "version": "2.0.0_dev1",
   "environment": {},
   "custom": {
     "gear-builder": {

--- a/manifest.json
+++ b/manifest.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "source": "https://github.com/flywheel-apps/GRP-15",
   "url": "https://github.com/flywheel-apps/GRP-15",
-  "version": "2.0.0_dev1",
+  "version": "2.0.0_dev5",
   "environment": {},
   "custom": {
     "gear-builder": {

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-flywheel-sdk>=11.2.0
+flywheel-sdk~=12.0.0
 glob2

--- a/run.py
+++ b/run.py
@@ -328,9 +328,24 @@ def apply_template_to_project(gear_context, project, template, fixed_input_archi
         if gear_context.config.get('default_group_permissions'):
             log.info(f'Applying default group permissions...')
             permissions = fw.get_group(project.group).permissions
+            
+            perm_lookup = fw.get_all_roles()
+            new_perm_list = []
+            
+            for perm in permissions:
+                rix = [r.label for r in perm_lookup].index(perm.access)
+                role_id = perm_lookup[rix].id
+                new_perm_list.append(flywheel.RolesRoleAssignment(perm.id, role_id))
+
+            permissions = new_perm_list
+            
+            
         else:
             permissions = template['permissions']
         for permission in permissions:
+            
+            log.debug(pp(permission))
+            
             if not isinstance(permission,  flywheel.models.roles_role_assignment.RolesRoleAssignment):
                 permission = flywheel.RolesRoleAssignment(permission['id'], permission['role_ids'])
             if (permission.id not in users) and (permission.id in all_users):

--- a/run.py
+++ b/run.py
@@ -89,7 +89,7 @@ def generate_project_template(gear_context, project, outname=None):
               "permissions": [
                 {
                   "id": "<user_id>",
-                  "access": "<access_rights>"
+                  "role_ids": "[ <access_rights> ]"
                 }
               ],
               "rules": [
@@ -137,7 +137,7 @@ def generate_project_template(gear_context, project, outname=None):
     rules = [ r.to_dict() for r in fw.get_project_rules(project.id) ]
 
     if gear_context.config.get('permissions'):
-        template['permissions'] = [ p.to_dict() for p in project.permissions ]
+        template['permissions'] = [p.to_dict() for p in project.permissions ]
     else:
         template['permissions'] = list()
 
@@ -331,11 +331,11 @@ def apply_template_to_project(gear_context, project, template, fixed_input_archi
         else:
             permissions = template['permissions']
         for permission in permissions:
-            if not isinstance(permission, flywheel.models.permission.Permission):
-                permission = flywheel.Permission(permission['id'], permission['access'])
+            if not isinstance(permission,  flywheel.models.roles_role_assignment.RolesRoleAssignment):
+                permission = flywheel.RolesRoleAssignment(permission['id'], permission['role_ids'])
             if (permission.id not in users) and (permission.id in all_users):
                 log.info(' Adding {} to {}'.format(permission.id, project.label))
-                project.add_permission(flywheel.Permission(permission.id, permission.access))
+                project.add_permission(flywheel.RolesRoleAssignment(permission.id, permission.role_ids))
             else:
                 log.warning(' {} will not be added to {}. The user is either already in the project or not a valid user.'.format(permission.id, project.label))
         log.info('...PERMISSIONS APPLIED')


### PR DESCRIPTION
Made the code smoother but honestly didn't change the function.  Duplicate role names aren't super important because the template has role ID's which are unique, which is used to set the roles in the new project.  